### PR TITLE
[Bug] Remove ML Packages

### DIFF
--- a/parseRuleData.ts
+++ b/parseRuleData.ts
@@ -169,25 +169,6 @@ async function precomputeRuleSummaries() {
   fs.mkdirSync(RULES_OUTPUT_PATH, { recursive: true });
 
   await getPrebuiltDetectionRules(ruleSummaries, tagSummaries);
-  await getPackageRules('dga', 'DGA', ruleSummaries, tagSummaries);
-  await getPackageRules(
-    'ded',
-    'Data Exfiltration Detection',
-    ruleSummaries,
-    tagSummaries
-  );
-  await getPackageRules(
-    'lmd',
-    'Lateral Movement Detection',
-    ruleSummaries,
-    tagSummaries
-  );
-  await getPackageRules(
-    'problemchild',
-    'Living off the Land Attack Detection',
-    ruleSummaries,
-    tagSummaries
-  );
 
   console.log(`loaded ${ruleSummaries.length} rules`);
   console.log(`example rule:`);

--- a/src/pages/rules/[id].tsx
+++ b/src/pages/rules/[id].tsx
@@ -197,17 +197,19 @@ export default function RuleDetails({
     },
     {
       title: 'Related Integrations',
-      description:
-        rule.metadata.integration &&
-        rule.metadata.integration.map((x, i) => (
-          <p key={i}>
-            <EuiLink
-              target="_blank"
-              href={`https://docs.elastic.co/en/integrations/${x}`}>
-              {x}
-            </EuiLink>
-          </p>
-        )),
+      description: [
+        ...(Array.isArray(rule.metadata.integration)
+          ? rule.metadata.integration
+          : [rule.metadata.integration]),
+      ].map((x, i) => (
+        <p key={i}>
+          <EuiLink
+            target="_blank"
+            href={`https://docs.elastic.co/en/integrations/${x}`}>
+            {x}
+          </EuiLink>
+        </p>
+      )),
     },
     {
       title: 'Query',


### PR DESCRIPTION
## Related Issues
https://github.com/elastic/detection-rules-explorer/issues/2

## Summary

This PR removes looking for these ML packages from `parseRuleData.ts` to address the above issue. 

See the [error output](https://github.com/elastic/ia-trade-team/discussions/194#discussioncomment-7327477) as an example.

Additionally this fixes a hard coded data ingestion error where it initially only supported the rule data for `metadata.integration` to be a list/array. However, in the detection rules [dataclass object definition](https://github.com/elastic/detection-rules/blob/dff4633dd44d68255369498cb51f56a949aff2dd/detection_rules/rule.py#L59C11-L59C11) this could be either a list or a string. 

<details><summary>Example</summary>
<p>

![image](https://github.com/elastic/detection-rules-explorer/assets/119343520/c61dc450-4b6e-4677-ac7e-1d0f7f4c8413)


</p>
</details>  

## Testing

Use either the commands from the README if you wish to use your local node installation, or use the following Docker container to test. 

**Docker Instructions**
1. Clone `detection-rules-explorer` and cd into the newly cloned directory
1. Create a `Dockerfile` with the following contents

    <details><summary>Dockerfile</summary>
    <p>
    
    ```Dockerfile
    FROM node:18.16.1-alpine3.17
    RUN mkdir -p /opt/app
    WORKDIR /opt/app
    COPY package.json package-lock.json /opt/app/
    RUN npm ci
    COPY . .
    RUN npm run build && npm run export && touch ./out/.nojekyll
    CMD [ "npm", "start"]
    ```
    
    </p>
    </details> 
    
1. Run `docker build -t rules_explorer_test .` to build the container
1. Run `docker run rules_explorer_test` to start the container
1. Navigate to `10.10.0.2:3000` to view the explorer (note this is http NOT https)
    * Note this IP address may be different for you depending on your Docker setup or if you are running additional containers.
    * You can use the `docker container list` command to find your running container
        <details><summary>Example</summary>
        <p>
        
        ```shell
        ❯ docker container list
        CONTAINER ID   IMAGE                                         COMMAND                  CREATED          STATUS          PORTS                                       NAMES
        c0a434dbfde6   rules_explorer_test                           "docker-entrypoint.s…"   37 seconds ago   Up 37 seconds   443/tcp                                     determined_lehmann
        
        
        ```
        
        </p>
        </details> 
    * Now you can grab the `CONTAINER ID` and use it to get the IP address via the following `docker inspect <container_id> | grep IPAddress` 
        <details><summary>Example</summary>
        <p>
        
        ```shell
        detection-rules-explorer on  remove_ml_packages [!?] via  v20.9.0 on  eric.forte 
        ❯ docker inspect 1ae633496a1b | grep IPAddress
                    "SecondaryIPAddresses": null,
                    "IPAddress": "10.10.0.2",
                            "IPAddress": "10.10.0.2",
        ```
        
        </p>
        </details> 
1. Check to make sure you can navigate to the integrations for a given rule (note it may take a minute to load)
  
    ![detection_rules_explorer](https://github.com/elastic/detection-rules-explorer/assets/119343520/5326f3b1-efc3-4207-b73e-483f05f45f05)
