### PR TITLE
[FR] Add Support for Threat Hunting Queries and Language Filtering

### DIFF
--- a/parseRuleData.ts
+++ b/parseRuleData.ts
@@ -156,17 +156,9 @@ async function getPrebuiltDetectionRules(
     setDefault(ruleContent.rule, 'license', "Elastic License v2");
     setDefault(ruleContent.rule, 'description', ruleContent.hunt?.description);
 
-    // // Print out rule.threat if it exists
-    // if (ruleContent.rule.threat) {
-    //   console.log('rule.threat:', JSON.stringify(ruleContent.rule.threat, null, 2));
-    // }
     // Convert hunt.mitre to rule.threat if hunt.mitre exists
     if (ruleContent.hunt?.mitre) {
       ruleContent.rule.threat = convertHuntMitre(ruleContent.hunt.mitre);
-        // Print out rule.threat if it exists
-        if (ruleContent.rule.threat) {
-          console.log('rule.threat:', JSON.stringify(ruleContent.rule.threat, null, 2));
-        }
     }
   
     ruleSummaries.push({

--- a/parseRuleData.ts
+++ b/parseRuleData.ts
@@ -138,7 +138,13 @@ async function getPrebuiltDetectionRules(
     // Use default tags if ruleContent.rule.tags does not exist
     const tags = ruleContent.rule.tags || ["Hunt Type: Hunt"];
     setDefault(ruleContent.rule, 'tags', ["Hunt Type: Hunt"]);
-  
+
+    // Add a tag based on the language
+    const language = ruleContent.rule?.language;
+    if (language) {
+      tags.push(`Language: ${language}`);
+    }
+
     // Add creation_date and updated_date if they do not exist
     const defaultDate = new Date(0).toISOString();
     setDefault(ruleContent.metadata, 'creation_date', defaultDate);

--- a/src/components/home/home_hero.tsx
+++ b/src/components/home/home_hero.tsx
@@ -159,6 +159,13 @@ const HomeHero: FunctionComponent<RuleFilterProps> = ({
             tagFilter={tagFilter}
             onTagChange={onTagChange}
           />
+          <RuleFilter
+            displayName="Rule Languages"
+            icon="menu"
+            tagList={tagSummaries.filter(x => x.tag_type == 'Language')}
+            tagFilter={tagFilter}
+            onTagChange={onTagChange}
+          />
         </EuiFlexGrid>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/components/home/home_hero.tsx
+++ b/src/components/home/home_hero.tsx
@@ -151,6 +151,14 @@ const HomeHero: FunctionComponent<RuleFilterProps> = ({
             tagFilter={tagFilter}
             onTagChange={onTagChange}
           />
+
+          <RuleFilter
+            displayName="Threat Hunt Queries"
+            icon="eye"
+            tagList={tagSummaries.filter(x => x.tag_type == 'Hunt Type')}
+            tagFilter={tagFilter}
+            onTagChange={onTagChange}
+          />
         </EuiFlexGrid>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/lib/ruledata.ts
+++ b/src/lib/ruledata.ts
@@ -11,6 +11,14 @@ export const ruleFilterTypeMap = {
     color: 'default',
     icon: 'database',
   },
+  'Hunt Type': {
+    color: 'default',
+    icon: 'eye',
+  },
+  Language: {
+    color: 'default',
+    icon: 'menu',
+  },
   OS: {
     color: 'success',
     icon: 'compute',

--- a/src/lib/ruledata.ts
+++ b/src/lib/ruledata.ts
@@ -27,4 +27,8 @@ export const ruleFilterTypeMap = {
     color: 'hollow',
     icon: 'layers',
   },
+  Language: {
+    color: 'default',
+    icon: 'menu',
+  },
 };

--- a/src/lib/ruledata.ts
+++ b/src/lib/ruledata.ts
@@ -15,10 +15,6 @@ export const ruleFilterTypeMap = {
     color: 'default',
     icon: 'eye',
   },
-  Language: {
-    color: 'default',
-    icon: 'menu',
-  },
   OS: {
     color: 'success',
     icon: 'compute',


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/elastic/detection-rules-explorer/issues/4

## Summary

This PR adds support for using the rules explorer to view threat hunting toml files from detection rules. Given that the threat hunting toml objects have less information than their rule counter parts there are a few limitations. However, these are fairly minor and it still would be valuable to add them into the rules explorer. 

### Known Limitations

-  There is no created date or updated date are part of the threat hunting toml, as such they are currently set to a default date of UTC 0
![image](https://github.com/user-attachments/assets/ebc07e0d-f5cd-447a-8d33-c5458aecdffe)

- There is no name for the MITRE information, additionally some just have tactics or techniques and not both. As such in the current implementation these will show up as none if there are none `()` in the UI. Also, the tactic and technique name are not included in the toml file and only the ID is displayed
![image](https://github.com/user-attachments/assets/df70bd75-45ce-415b-8767-4bb0bbbcecb8)

- Currently there is no license attached to the threat hunting queries so I hard coded the v2 license, but we may want to remove this and have it be unlicensed.
![image](https://github.com/user-attachments/assets/bf8eb432-9089-48f3-b0a6-a172328aaf71)


## Testing

Use either the commands from the README if you wish to use your local node installation, or use the following Docker container to test. 

**Docker Instructions**
1. Clone `detection-rules-explorer` and cd into the newly cloned directory
1. Create a `Dockerfile` with the following contents

    <details><summary>Dockerfile</summary>
    <p>
    
    ```Dockerfile
    FROM node:18.16.1-alpine3.17
    RUN mkdir -p /opt/app
    WORKDIR /opt/app
    COPY package.json package-lock.json /opt/app/
    RUN npm ci
    COPY . .
    RUN npm run build && npm run export && touch ./out/.nojekyll
    CMD [ "npm", "start"]
    ```
    
    </p>
    </details> 
    
1. Run `docker build -t rules_explorer_test .` to build the container
1. Run `docker run rules_explorer_test` to start the container
1. Navigate to `10.10.0.2:3000` to view the explorer (note this is http NOT https)
    * Note this IP address may be different for you depending on your Docker setup or if you are running additional containers.
    * You can use the `docker container list` command to find your running container
        <details><summary>Example</summary>
        <p>
        
        ```shell
        ❯ docker container list
        CONTAINER ID   IMAGE                                         COMMAND                  CREATED          STATUS          PORTS                                       NAMES
        c0a434dbfde6   rules_explorer_test                           "docker-entrypoint.s…"   37 seconds ago   Up 37 seconds   443/tcp                                     determined_lehmann
        
        
        ```
        
        </p>
        </details> 
    * Now you can grab the `CONTAINER ID` and use it to get the IP address via the following `docker inspect <container_id> | grep IPAddress` 
        <details><summary>Example</summary>
        <p>
        
        ```shell
        detection-rules-explorer on  remove_ml_packages [!?] via  v20.9.0 on  eric.forte 
        ❯ docker inspect 1ae633496a1b | grep IPAddress
                    "SecondaryIPAddresses": null,
                    "IPAddress": "10.10.0.2",
                            "IPAddress": "10.10.0.2",
        ```
        
        </p>
        </details> 
1. Check to make sure you can navigate to the threat hunting queries and that they render as intended
  
![threat_hunt_2](https://github.com/user-attachments/assets/53351159-a688-4bd1-a0b0-024b7f1a8b18)


Also check for Language Filtering (note this purposefully does not include Threat Hunting Queries) 
![LanguageFilter](https://github.com/user-attachments/assets/8a7deef0-c43a-41fb-b6b1-063a62f80d37)
