### PR TITLE
chore(deps): apply low-risk Renovate dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,11 @@
         "@next/bundle-analyzer": "^12.3.7",
         "@types/node": "^16.18.126",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
-        "axios": "^1.14.0",
+        "axios": "^1.18.0",
         "copy-webpack-plugin": "^13.0.1",
         "eslint": "^8.57.1",
         "eslint-config-next": "^12.3.7",
-        "eslint-config-prettier": "^8.10.2",
+        "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-prettier": "^4.2.5",
         "glob": "^7.2.0",
         "iniparser": "^1.0.5",
@@ -2457,9 +2457,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3850,13 +3850,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
-      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "@next/bundle-analyzer": "^12.3.7",
     "@types/node": "^16.18.126",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "axios": "^1.14.0",
+    "axios": "^1.18.0",
     "copy-webpack-plugin": "^13.0.1",
     "eslint": "^8.57.1",
     "eslint-config-next": "^12.3.7",
-    "eslint-config-prettier": "^8.10.2",
+    "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-prettier": "^4.2.5",
     "glob": "^7.2.0",
     "iniparser": "^1.0.5",
@@ -46,11 +46,11 @@
     "typescript-plugin-css-modules": "^5.2.0"
   },
   "overrides": {
-    "trim": "0.0.3",
+    "trim": "1.0.1",
     "prismjs": "^1.30.0",
     "postcss": ">=8.4.31"
   },
   "resolutions": {
-    "trim": "0.0.3"
+    "trim": "1.0.1"
   }
 }


### PR DESCRIPTION
## Related Issues
Resolves #32, #36, #39


## Summary

Applies the subset of open Renovate (`elastic-renovate-prod`) dependency PRs that
carry little/no risk. Each was verified locally with `npm run lint`, a
`parseRuleData` TypeScript compile, and a full `tsc --noEmit` app typecheck.


## Libraries updated

| Dependency | From | To | Type | Notes |
|---|---|---|---|---|
| `axios` | `^1.14.0` | `^1.18.0` | devDependency | Minor bump within v1, no breaking changes. Only used at build time in `parseRuleData.ts`. |
| `eslint-config-prettier` | `^8.10.2` | `^10.0.0` | devDependency | Lint-only; merely disables ESLint rules that conflict with Prettier. Compatible with our ESLint 8. |
| `trim` | `0.0.3` | `1.0.1` | override/resolution | Security-pin safety net only. `trim` is not actually present in the dependency tree (`npm ls trim` is empty); `1.0.1` is the ReDoS-fixed release. |



## Testing

#### Screenshots 

<img width="1897" height="1005" alt="image" src="https://github.com/user-attachments/assets/a198e3bd-7f49-436a-a544-c4528f861690" />

<img width="1897" height="1005" alt="image" src="https://github.com/user-attachments/assets/08b441d2-46bf-4b79-b3ea-1e98c64fd6df" />


#### Local Test Steps

Use either the commands from the README if you wish to use your local node installation, or use the following Docker container to test. 

**Docker Instructions**
1. Clone `detection-rules-explorer` and cd into the newly cloned directory
1. Create a `Dockerfile` with the following contents

    <details><summary>Dockerfile</summary>
    <p>
    
    ```Dockerfile
    FROM node:20.19.3-alpine
    RUN mkdir -p /opt/app
    WORKDIR /opt/app
    COPY package.json package-lock.json /opt/app/
    RUN npm ci
    COPY . .
    RUN npm run build && npm run export
    CMD [ "npm", "start"]
    ```
    
    </p>
    </details> 
    
1. Run `docker build -t rules_explorer_test .` to build the container
1. Run `docker run rules_explorer_test` to start the container
1. Navigate to `10.10.0.2:3000` to view the explorer (note this is http NOT https)
    * Note this IP address may be different for you depending on your Docker setup or if you are running additional containers.
    * You can use the `docker container list` command to find your running container
        <details><summary>Example</summary>
        <p>
        
        ```shell
        ❯ docker container list
        CONTAINER ID   IMAGE                                         COMMAND                  CREATED          STATUS          PORTS                                       NAMES
        c0a434dbfde6   rules_explorer_test                           "docker-entrypoint.s…"   37 seconds ago   Up 37 seconds   443/tcp                                     determined_lehmann
        
        
        ```
        
        </p>
        </details> 
    * Now you can grab the `CONTAINER ID` and use it to get the IP address via the following `docker inspect <container_id> | grep IPAddress` 
        <details><summary>Example</summary>
        <p>
        
        ```shell
        detection-rules-explorer on  remove_ml_packages [!?] via  v20.9.0 on  eric.forte 
        ❯ docker inspect 1ae633496a1b | grep IPAddress
                    "SecondaryIPAddresses": null,
                    "IPAddress": "10.10.0.2",
                            "IPAddress": "10.10.0.2",
        ```
        
        </p>
        </details> 
1. Check to make sure the website renders as intended.