### PR TITLE
chore: Add explicit write permissions block

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
## Summary

Small update to add an explicit write permissions block to our gh page publishing workflow. 